### PR TITLE
mark config optional as there is a fallback {}

### DIFF
--- a/plugins/relay-global-id/src/index.ts
+++ b/plugins/relay-global-id/src/index.ts
@@ -96,7 +96,7 @@ export function relayGlobalIdPlugin(pluginConfig: RelayGlobalIdPluginConfig = {}
           name: nexusFieldName,
           typeDefinition: `<FieldName extends string>(
             fieldName: FieldName, 
-            config: RelayGlobalIdNexusFieldConfig<TypeName, FieldName>
+            config?: RelayGlobalIdNexusFieldConfig<TypeName, FieldName>
           ): void`,
           factory({ typeName: parentTypeName, typeDef: t, args: factoryArgs }) {
             const [fieldName, fieldConfig = {}] = factoryArgs as [


### PR DESCRIPTION
otherwise, nexus requires to provide empty object